### PR TITLE
generic-types-go: Added DockerPort.Empty()

### DIFF
--- a/port.go
+++ b/port.go
@@ -112,6 +112,11 @@ func (d *DockerPort) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Empty returns true if this port is equal to "", false otherwise.
+func (d *DockerPort) Empty() bool {
+	return d.Port == "" // Protocol can be set automatically to TCP so don't check that
+}
+
 func (d *DockerPort) Equals(other DockerPort) bool {
 	return d.Port == other.Port && d.Protocol == other.Protocol
 }

--- a/port_test.go
+++ b/port_test.go
@@ -99,3 +99,21 @@ func TestDockerPort__InalidJSONInput(t *testing.T) {
 
 	}
 }
+
+var emptyDockerPortJsonInput = []struct {
+	Input   DockerPort
+	IsEmpty bool
+}{
+	{DockerPort{Port: "", Protocol: ""}, true},
+	{DockerPort{Port: "80", Protocol: ""}, false},
+	{DockerPort{Port: "123", Protocol: "tcp"}, false},
+}
+
+func TestDockerPort_Empty(t *testing.T) {
+	for _, data := range emptyDockerPortJsonInput {
+		empty := data.Input.Empty()
+		if empty != data.IsEmpty {
+			t.Fatalf("Expected Empty() to return %v, got %v", data.IsEmpty, empty)
+		}
+	}
+}


### PR DESCRIPTION
Added check for emptyness of a DockerPort structure.