### PR TITLE
generic-types-go: Removed UpdateTLDs from init()

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -11,6 +11,7 @@ import (
 )
 
 var (
+	maskAny        = errgo.MaskFunc(errgo.Any)
 	updatedTLDs    bool
 	updateTLDMutex sync.Mutex
 )
@@ -18,9 +19,9 @@ var (
 // updateTLDsIfNeeded performs a webrequest to update the
 // list of toplevel domain names.
 // This is done only once per process.
-func updateTLDsIfNeeded() {
+func updateTLDsIfNeeded() error {
 	if updatedTLDs {
-		return
+		return nil
 	}
 
 	updateTLDMutex.Lock()
@@ -29,10 +30,11 @@ func updateTLDsIfNeeded() {
 	if !updatedTLDs {
 		// Fetch a new list of TLDs from the internet on startup.
 		if err := web.UpdateTLDs(web.IANA); err != nil {
-			log.Printf("[ERROR] Failed to update TLDs: %v\n", err)
+			return maskAny(err)
 		}
 		updatedTLDs = true
 	}
+	return nil
 }
 
 type Domain string
@@ -62,11 +64,15 @@ func (d *Domain) String() string {
 }
 
 func (d *Domain) Validate() error {
-	updateTLDsIfNeeded()
+	if err := updateTLDsIfNeeded(); err != nil {
+		// We don't fail Validate here, because we still have a backup
+		// with our builtin TLD list.
+		log.Printf("[ERROR] Failed to update TLDs: %v\n", err)
+	}
 	v := validate.NewValidator()
 
 	if err := v.Validate(web.NewDomain(d.String())); err != nil {
-		return errgo.Mask(errgo.Newf("Invalid domain: %s", d.String()), errgo.Any)
+		return maskAny(errgo.Newf("Invalid domain: %s", d.String()))
 	}
 
 	return nil

--- a/domain.go
+++ b/domain.go
@@ -3,16 +3,35 @@ package generictypes
 import (
 	"encoding/json"
 	"log"
+	"sync"
 
 	"github.com/giantswarm/validate"
 	"github.com/giantswarm/validate/web"
 	"github.com/juju/errgo"
 )
 
-func init() {
-	// Fetch a new list of TLDs from the internet on startup.
-	if err := web.UpdateTLDs(web.IANA); err != nil {
-		log.Printf("[ERROR] Failed to update TLDs: %v\n", err)
+var (
+	updatedTLDs    bool
+	updateTLDMutex sync.Mutex
+)
+
+// updateTLDsIfNeeded performs a webrequest to update the
+// list of toplevel domain names.
+// This is done only once per process.
+func updateTLDsIfNeeded() {
+	if updatedTLDs {
+		return
+	}
+
+	updateTLDMutex.Lock()
+	defer updateTLDMutex.Unlock()
+
+	if !updatedTLDs {
+		// Fetch a new list of TLDs from the internet on startup.
+		if err := web.UpdateTLDs(web.IANA); err != nil {
+			log.Printf("[ERROR] Failed to update TLDs: %v\n", err)
+		}
+		updatedTLDs = true
 	}
 }
 
@@ -43,6 +62,7 @@ func (d *Domain) String() string {
 }
 
 func (d *Domain) Validate() error {
+	updateTLDsIfNeeded()
 	v := validate.NewValidator()
 
 	if err := v.Validate(web.NewDomain(d.String())); err != nil {


### PR DESCRIPTION
This change no longer calls go-tld.Update during `init()`.
Instead it delays calling it to when it really wants to validate a domain name.